### PR TITLE
Docker images: set pip timeout to 180

### DIFF
--- a/base-foundations-ml-python/Dockerfile
+++ b/base-foundations-ml-python/Dockerfile
@@ -25,6 +25,7 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
     PIP_DEFAULT_TIMEOUT=100 \
+    PIP_REQUESTS_TIMEOUT=180 \
     # Poetry env vars (https://python-poetry.org/docs/configuration/#using-environment-variables)
     POETRY_VERSION=1.5.1 \
     POETRY_NO_INTERACTION=1

--- a/base-foundations-python/Dockerfile
+++ b/base-foundations-python/Dockerfile
@@ -21,6 +21,7 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
     PIP_DEFAULT_TIMEOUT=100 \
+    PIP_REQUESTS_TIMEOUT=180 \
     # Poetry env vars (https://python-poetry.org/docs/configuration/#using-environment-variables)
     POETRY_VERSION=1.5.1 \ 
     POETRY_NO_INTERACTION=1


### PR DESCRIPTION
Some developers in the local environment were seeing issues where poetry/pip installs were timing out, blocking dependency installs.

We only have one helpful error message from a developer and can't reproduce the issue, but we're tweaking the Pip timeout here as a "shot in the dark" to try and reduce the probability that this happens in the future.

https://app.asana.com/0/1205204969927028/1206888509893734/f