### PR TITLE
base: remove pinned versions in apt-get install

### DIFF
--- a/base-foundations-python/Dockerfile
+++ b/base-foundations-python/Dockerfile
@@ -1,12 +1,12 @@
 FROM python:3.10.6-slim-buster as base-foundations-python
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    libpq-dev=11.20-0+deb10u1 \
-    python3-dev=3.7.3-1 \
-    build-essential=12.6 \
-    gcc=4:8.3.0-1 \
-    jq=1.5+dfsg-2+b1 \
-    curl=7.64.0-4+deb10u6 \
+    libpq-dev \
+    python3-dev \
+    build-essential \
+    gcc \
+    jq \
+    curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Some of these versions do not exist, and we always want the latest version of these anyway. We trust the Debian repos.

See here for example of failure due to status quo: https://app.harness.io/ng/account/uHZJN3pqSdORjA0KQA2kWw/module/ci/orgs/lumos_main/projects/foundations/pipelines/build_and_push_base_python_image/executions/4e5ViP4MRrSOjqVzeaVuMQ/pipeline?connectorRef=account.Github_PAT&repoName=teamlumos/lumos&branch=dev&storeType=REMOTE&stage=wk_UGWbkRCqg6PkvFRQOHg

We have not updated this image in 5 months