### PR TITLE
base: update package versions for libpq-dev and curl

### DIFF
--- a/base-foundations-ml-python/Dockerfile
+++ b/base-foundations-ml-python/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libgomp1=8.3.0-6 \
     gcc=4:8.3.0-1 \
     jq=1.5+dfsg-2+b1 \
-    curl=7.64.0-4+deb10u6 \
-    libpq-dev=11.20-0+deb10u1 \
+    curl=7.64.0-4+deb10u9 \
+    libpq-dev=11.22-0+deb10u2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/base-foundations-python/Dockerfile
+++ b/base-foundations-python/Dockerfile
@@ -1,12 +1,12 @@
 FROM python:3.10.6-slim-buster as base-foundations-python
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    libpq-dev=11.20-0+deb10u1 \
+    libpq-dev=11.22-0+deb10u2 \
     python3-dev=3.7.3-1 \
     build-essential=12.6 \
     gcc=4:8.3.0-1 \
     jq=1.5+dfsg-2+b1 \
-    curl=7.64.0-4+deb10u6 \
+    curl=7.64.0-4+deb10u9 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -23,7 +23,7 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100 \
     PIP_REQUESTS_TIMEOUT=180 \
     # Poetry env vars (https://python-poetry.org/docs/configuration/#using-environment-variables)
-    POETRY_VERSION=1.5.1 \ 
+    POETRY_VERSION=1.5.1 \
     POETRY_NO_INTERACTION=1
 
 RUN \
@@ -33,4 +33,3 @@ RUN \
     virtualenv==20.23.1 \
     "poetry==$POETRY_VERSION" \
     && poetry config virtualenvs.create false
-


### PR DESCRIPTION
https://app.asana.com/0/1207149835149582/1208352927897581/f

Running `docker build` throws the following error

```
1.722 E: Version '11.20-0+deb10u1' for 'libpq-dev' was not found
1.722 E: Version '7.64.0-4+deb10u6' for 'curl' was not found
------
Dockerfile:3
--------------------
   2 |
   3 | >>> RUN apt-get update && apt-get install --no-install-recommends -y \
   4 | >>>     libpq-dev=11.20-0+deb10u1 \
   5 | >>>     python3-dev=3.7.3-1 \
   6 | >>>     build-essential=12.6 \
   7 | >>>     gcc=4:8.3.0-1 \
   8 | >>>     jq=1.5+dfsg-2+b1 \
   9 | >>>     curl=7.64.0-4+deb10u6 \
  10 | >>>     && apt-get clean \
  11 | >>>     && rm -rf /var/lib/apt/lists/*
  12 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update && apt-get install --no-install-recommends -y     libpq-dev=11.20-0+deb10u1     python3-dev=3.7.3-1     build-essential=12.6     gcc=4:8.3.0-1     jq=1.5+dfsg-2+b1     curl=7.64.0-4+deb10u6     && apt-get clean     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```

Looking at the Debian package site, the next stable version for libpq-dev is `11.22-0+deb10u2`
https://packages.debian.org/search?searchon=names&keywords=libpq-dev

and `7.64.0-4+deb10u9` for curl
https://packages.debian.org/search?searchon=names&keywords=curl