### PR TITLE
poetry: downgrade base to 1.3.2

### DIFF
--- a/base-foundations-ml-python/Dockerfile
+++ b/base-foundations-ml-python/Dockerfile
@@ -27,7 +27,7 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100 \
     PIP_REQUESTS_TIMEOUT=180 \
     # Poetry env vars (https://python-poetry.org/docs/configuration/#using-environment-variables)
-    POETRY_VERSION=1.5.1 \
+    POETRY_VERSION=1.3.2 \
     POETRY_NO_INTERACTION=1
 
 RUN \

--- a/base-foundations-python/Dockerfile
+++ b/base-foundations-python/Dockerfile
@@ -28,7 +28,7 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100 \
     PIP_REQUESTS_TIMEOUT=180 \
     # Poetry env vars (https://python-poetry.org/docs/configuration/#using-environment-variables)
-    POETRY_VERSION=1.5.1 \
+    POETRY_VERSION=1.3.2 \
     POETRY_NO_INTERACTION=1
 
 RUN \


### PR DESCRIPTION
Currently, our monorepo downgrades poetry to 1.3.2. I tried to remove the downgrade step in the past, and it led to a production outage ([incident](https://lumos-app.slack.com/archives/C084FNRAFSA), [revert PR](https://github.com/teamlumos/lumos/pull/23096)). Until the reason for the upgrade outage is identified, we should at least only install poetry once

Relates to https://github.com/teamlumos/lumos/pull/25360